### PR TITLE
Add steel area plot

### DIFF
--- a/viga2.0.py
+++ b/viga2.0.py
@@ -289,7 +289,9 @@ class DesignWindow(QMainWindow):
         self.as_total = QLabel("-")
         layout.addWidget(self.as_total, 2, 3, 1, 2)
 
-        self.fig_sec, self.ax_sec = plt.subplots(figsize=(4, 4))
+        self.fig_sec, (self.ax_sec, self.ax_dist) = plt.subplots(
+            2, 1, figsize=(4, 7), constrained_layout=True
+        )
         self.canvas = FigureCanvas(self.fig_sec)
         layout.addWidget(self.canvas, 3, 0, 1, 5)
 
@@ -318,6 +320,7 @@ class DesignWindow(QMainWindow):
         for ed in self.edits.values():
             ed.editingFinished.connect(self.draw_section)
         self.draw_section()
+        self.draw_beam_distribution()
         self.update_as()
 
     def draw_section(self):
@@ -349,6 +352,42 @@ class DesignWindow(QMainWindow):
         self.ax_sec.set_xlim(-10, b + 10)
         self.ax_sec.set_ylim(-10, h + 10)
         self.ax_sec.axis('off')
+        self.canvas.draw()
+
+    def draw_beam_distribution(self):
+        """Display As- and As+ values along a horizontal beam."""
+        x_ctrl = [0.0, 0.5, 1.0]
+        areas_n = np.abs(self.mn_corr)
+        areas_p = np.abs(self.mp_corr)
+
+        self.ax_dist.clear()
+        self.ax_dist.plot([0, 1], [0, 0], 'k-', lw=6)
+
+        y_off = 0.1 * max(np.max(areas_n), np.max(areas_p), 1)
+        for x, a_n in zip(x_ctrl, areas_n):
+            self.ax_dist.text(
+                x,
+                y_off,
+                f"As- {a_n:.2f}",
+                ha='center',
+                va='bottom',
+                color='b',
+                fontsize=9,
+            )
+        for x, a_p in zip(x_ctrl, areas_p):
+            self.ax_dist.text(
+                x,
+                -y_off,
+                f"As+ {a_p:.2f}",
+                ha='center',
+                va='top',
+                color='r',
+                fontsize=9,
+            )
+
+        self.ax_dist.set_xlim(-0.05, 1.05)
+        self.ax_dist.set_ylim(-2 * y_off, 2 * y_off)
+        self.ax_dist.axis('off')
         self.canvas.draw()
 
     def _bar_area(self, d_text):


### PR DESCRIPTION
## Summary
- add constant table of bar areas
- include new inputs for steel quantity, diameter and As along beam
- display a graph of designed steel area across three sections

## Testing
- `python -m py_compile viga2.0.py`

------
https://chatgpt.com/codex/tasks/task_e_6848f9ce54ec832b96e171e918a7695a